### PR TITLE
Support unwrapping single arg ctors & ignore values for nullary ctors

### DIFF
--- a/src/Data/Argonaut/Types/Generic/Rep.purs
+++ b/src/Data/Argonaut/Types/Generic/Rep.purs
@@ -3,14 +3,20 @@ module Data.Argonaut.Types.Generic.Rep (
   defaultEncoding
 ) where
 
+-- | Encoding settings:
+-- | tagKey -- which key to use in the JSON object for sum-type constructors
+-- | valuesKey -- which key to use in the JSON object for sum-type values
+-- | unwrapSingleArguments -- should single-arguments constructors' values be wrapped in an array
 type Encoding =
   { tagKey :: String
   , valuesKey :: String
+  , unwrapSingleArguments :: Boolean
   }
 
 defaultEncoding :: Encoding
 defaultEncoding =
   { tagKey: "tag"
   , valuesKey: "values"
+  , unwrapSingleArguments: false
   }
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -65,6 +65,21 @@ instance encodeJsonDiffEncoding :: EncodeJson DiffEncoding where
 instance decodeJsonDiffEncoding :: DecodeJson DiffEncoding where
   decodeJson a = genericDecodeJsonWith diffEncodingOptions a
 
+unwrapSingleArgsOptions :: Encoding
+unwrapSingleArgsOptions = defaultEncoding
+  { unwrapSingleArguments = true
+  }
+
+data UnwrapSingleArgs = U0 Int | U1 Int Int
+derive instance eqUnwrapSingleArgs :: Eq UnwrapSingleArgs
+derive instance genericUnwrapSingleArgs :: Generic UnwrapSingleArgs _
+instance showUnwrapSingleArgs :: Show UnwrapSingleArgs where
+  show a = genericShow a
+instance encodeJsonUnwrapSingleArgs :: EncodeJson UnwrapSingleArgs where
+  encodeJson a = genericEncodeJsonWith unwrapSingleArgsOptions a
+instance decodeJsonUnwrapSingleArgs :: DecodeJson UnwrapSingleArgs where
+  decodeJson a = genericDecodeJsonWith unwrapSingleArgsOptions a
+
 main :: Effect Unit
 main = do
   example $ Either $ Left "foo"
@@ -75,6 +90,13 @@ main = do
   example $ Frikandel
   example $ A
   example $ B 42
+
+  example $ U0 42
+  assert $ stringify (encodeJson (U0 42)) == """{"values":42,"tag":"U0"}"""
+
+  example $ U1 1 2
+  assert $ stringify (encodeJson (U1 1 2)) == """{"values":[1,2],"tag":"U1"}"""
+
   testLiteralSumWithTransform identity Frikandel "\"Frikandel\""
   testLiteralSumWithTransform toUpper Frikandel "\"FRIKANDEL\""
   testLiteralSumWithTransform toLower Frikandel "\"frikandel\""
@@ -89,6 +111,7 @@ main = do
     log $ "From JSON: " <> show parsed
     assert $ parsed == Right original
     log $ "--------------------------------------------------------------------------------"
+
   testLiteralSumWithTransform :: forall a rep
     . Show a
     => Eq a

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -80,6 +80,16 @@ instance encodeJsonUnwrapSingleArgs :: EncodeJson UnwrapSingleArgs where
 instance decodeJsonUnwrapSingleArgs :: DecodeJson UnwrapSingleArgs where
   decodeJson a = genericDecodeJsonWith unwrapSingleArgsOptions a
 
+data IgnoreNullaryArgs = NA0 | NA1 Int
+derive instance eqIgnoreNullaryArgs :: Eq IgnoreNullaryArgs
+derive instance genericIgnoreNullaryArgs :: Generic IgnoreNullaryArgs _
+instance showIgnoreNullaryArgs :: Show IgnoreNullaryArgs where
+  show a = genericShow a
+instance encodeJsonIgnoreNullaryArgs :: EncodeJson IgnoreNullaryArgs where
+  encodeJson a = genericEncodeJson a
+instance decodeJsonIgnoreNullaryArgs :: DecodeJson IgnoreNullaryArgs where
+  decodeJson a = genericDecodeJson a
+
 main :: Effect Unit
 main = do
   example $ Either $ Left "foo"
@@ -100,6 +110,10 @@ main = do
   testLiteralSumWithTransform identity Frikandel "\"Frikandel\""
   testLiteralSumWithTransform toUpper Frikandel "\"FRIKANDEL\""
   testLiteralSumWithTransform toLower Frikandel "\"frikandel\""
+
+  example $ NA1 42
+  example $ NA0
+  assert $ (jsonParser """{"tag":"NA0"}""" >>= decodeJson) == Right NA0
 
   where
   example :: forall a. Show a => Eq a => EncodeJson a => DecodeJson a => a -> Effect Unit


### PR DESCRIPTION
Adds `unwrapSingleArguments :: Boolean` to the `Encoding` options.
Also, for nullary constructors, don't look for `values`.