### PR TITLE
Remove Data.Argonaut.Encode.Generic.Rep.EncodeRepFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable changes to this project are documented in this file. The format is based
 
 Breaking changes (😱!!!):
 
+- Removed vestigial `EncodeRepFields` class and its remaining instance for  `Data.Generic.Rep.Product`.
+
 New features:
 
 Bugfixes:

--- a/src/Data/Argonaut/Encode/Generic/Rep.purs
+++ b/src/Data/Argonaut/Encode/Generic/Rep.purs
@@ -1,12 +1,10 @@
 module Data.Argonaut.Encode.Generic.Rep (
   class EncodeRep,
   class EncodeRepArgs,
-  class EncodeRepFields,
   class EncodeLiteral,
   encodeRep,
   encodeRepWith,
   encodeRepArgs,
-  encodeRepFields,
   genericEncodeJson,
   genericEncodeJsonWith,
   encodeLiteralSum,
@@ -64,14 +62,6 @@ instance encodeRepArgsProduct :: (EncodeRepArgs a, EncodeRepArgs b) => EncodeRep
 
 instance encodeRepArgsArgument :: (EncodeJson a) => EncodeRepArgs (Rep.Argument a) where
   encodeRepArgs (Rep.Argument a) = [encodeJson a]
-
-class EncodeRepFields r where
-  encodeRepFields :: r -> FO.Object Json
-
-instance encodeRepFieldsProduct :: (EncodeRepFields a, EncodeRepFields b) => EncodeRepFields (Rep.Product a b) where
-  encodeRepFields (Rep.Product a b) =
-    FO.union (encodeRepFields a) (encodeRepFields b)
-
 
 -- | Encode any `Generic` data structure into `Json`.
 genericEncodeJson :: forall a r. Rep.Generic a r => EncodeRep r => a -> Json


### PR DESCRIPTION
`Data.Argonaut.Decode.Generic.Rep.DecodeRepFields` was removed when updating the library to v0.12.0 in https://github.com/purescript-contrib/purescript-argonaut-generic/pull/8 but this class was forgotten.

I updated the ”Breaking changes“ section of the changelog because this pull request removes an exported class, which is technically a breaking change, but nobody should depend on it anymore.
