### PR TITLE
Replace Slack links with Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: PureScript Discourse
     url: https://discourse.purescript.org/
-    about: Ask and answer questions here.
-  - name: Functional Programming Slack
-    url: https://functionalprogramming.slack.com
-    about: For casual chat and questions (use https://fpchat-invite.herokuapp.com to join).
+    about: Ask and answer questions on the PureScript discussion forum.
+  - name: PureScript Discord
+    url: https://discord.com/invite/sMqwYUbvz6/
+    about: Ask and answer questions on the PureScript chat.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You may also be interested in other libraries in the Argonaut ecosystem:
 If you get stuck, there are several ways to get help:
 
 - [Open an issue](https://github.com/purescript-contrib/purescript-argonaut-generic/issues) if you have encountered a bug or problem.
-- [Search or start a thread on the PureScript Discourse](https://discourse.purescript.org) if you have general questions. You can also ask questions in the `#purescript` and `#purescript-beginners` channels on the [Functional Programming Slack](https://functionalprogramming.slack.com) ([invite link](https://fpchat-invite.herokuapp.com/)).
+- Ask general questions on the [PureScript Discourse](https://discourse.purescript.org) forum or the [PureScript Discord](https://discord.com/invite/sMqwYUbvz6) chat.
 
 ## Contributing
 


### PR DESCRIPTION
We are migrating to Discord for chat related to the Contributors organization. This PR updates mentions of Slack in this repository to link to the PureScript Discord instead.