### PR TITLE
Introduce purs-tidy formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Set up a PureScript toolchain
         uses: purescript-contrib/setup-purescript@main
+        with:
+          purs-tidy: "latest"
 
       - name: Cache PureScript dependencies
         uses: actions/cache@v2
@@ -32,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: spago test --no-install
+
+      - name: Check formatting
+        run: purs-tidy check src test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 !.gitignore
 !.github
 !.editorconfig
+!.tidyrc.json
 
 output
 generated-docs

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "source",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Added `purs-tidy` formatter (#38 by @thomashoneyman)
 
 ## [v7.0.1](https://github.com/purescript-contrib/purescript-argonaut-generic/releases/tag/v7.0.1) - 2021-05-06
 

--- a/src/Data/Argonaut/Encode/Generic.purs
+++ b/src/Data/Argonaut/Encode/Generic.purs
@@ -1,16 +1,16 @@
-module Data.Argonaut.Encode.Generic (
-  class EncodeRep,
-  class EncodeRepArgs,
-  class EncodeLiteral,
-  encodeRep,
-  encodeRepWith,
-  encodeRepArgs,
-  genericEncodeJson,
-  genericEncodeJsonWith,
-  encodeLiteralSum,
-  encodeLiteralSumWithTransform,
-  encodeLiteral
-) where
+module Data.Argonaut.Encode.Generic
+  ( class EncodeRep
+  , class EncodeRepArgs
+  , class EncodeLiteral
+  , encodeRep
+  , encodeRepWith
+  , encodeRepArgs
+  , genericEncodeJson
+  , genericEncodeJsonWith
+  , encodeLiteralSum
+  , encodeLiteralSumWithTransform
+  , encodeLiteral
+  ) where
 
 import Prelude
 
@@ -44,13 +44,14 @@ instance encodeRepConstructor :: (IsSymbol name, EncodeRepArgs a) => EncodeRep (
       $ FO.insert e.valuesKey values
       $ FO.empty
     where
-      values =
-        let vs = encodeRepArgs a in
-        if e.unwrapSingleArguments
-          then case vs of
-            [v] -> v
-            _ -> fromArray vs
-          else fromArray vs
+    values =
+      let
+        vs = encodeRepArgs a
+      in
+        if e.unwrapSingleArguments then case vs of
+          [ v ] -> v
+          _ -> fromArray vs
+        else fromArray vs
 
 class EncodeRepArgs r where
   encodeRepArgs :: r -> Array Json
@@ -62,7 +63,7 @@ instance encodeRepArgsProduct :: (EncodeRepArgs a, EncodeRepArgs b) => EncodeRep
   encodeRepArgs (Rep.Product a b) = encodeRepArgs a <> encodeRepArgs b
 
 instance encodeRepArgsArgument :: (EncodeJson a) => EncodeRepArgs (Rep.Argument a) where
-  encodeRepArgs (Rep.Argument a) = [encodeJson a]
+  encodeRepArgs (Rep.Argument a) = [ encodeJson a ]
 
 -- | Encode any `Generic` data structure into `Json`.
 genericEncodeJson :: forall a r. Rep.Generic a r => EncodeRep r => a -> Json
@@ -95,7 +96,7 @@ instance encodeLiteralConstructor :: (IsSymbol name) => EncodeLiteral (Rep.Const
 type FailMessage =
   Text """`encodeLiteralSum` can only be used with sum types, where all of the constructors are nullary. This is because a string literal cannot be encoded into a product type."""
 
-instance encodeLiteralConstructorCannotBeProduct
-  :: Fail FailMessage
-  => EncodeLiteral (Rep.Product a b) where
+instance encodeLiteralConstructorCannotBeProduct ::
+  Fail FailMessage =>
+  EncodeLiteral (Rep.Product a b) where
   encodeLiteral _ _ = unsafeCrashWith "unreachable encodeLiteral was reached."

--- a/src/Data/Argonaut/Types/Generic.purs
+++ b/src/Data/Argonaut/Types/Generic.purs
@@ -1,7 +1,7 @@
-module Data.Argonaut.Types.Generic (
-  Encoding(..),
-  defaultEncoding
-) where
+module Data.Argonaut.Types.Generic
+  ( Encoding(..)
+  , defaultEncoding
+  ) where
 
 -- | Encoding settings:
 -- | tagKey -- which key to use in the JSON object for sum-type constructors

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -23,7 +23,7 @@ import Test.Assert (assert)
 
 data Example
   = Either (Either String Example)
-  | Record { foo :: Int, bar :: String}
+  | Record { foo :: Int, bar :: String }
   | Nested { foo :: { nested :: Int }, bar :: String }
   | Product Int Int Example
 
@@ -31,8 +31,10 @@ derive instance eqExample :: Eq Example
 derive instance genericExample :: Generic Example _
 instance showExample :: Show Example where
   show a = genericShow a
+
 instance encodeJsonExample :: EncodeJson Example where
   encodeJson a = genericEncodeJson a
+
 instance decodeJson :: DecodeJson Example where
   decodeJson a = genericDecodeJson a
 
@@ -45,8 +47,10 @@ derive instance eqLiteralStringExample :: Eq LiteralStringExample
 derive instance genericLiteralStringExample :: Generic LiteralStringExample _
 instance showLiteralStringExample :: Show LiteralStringExample where
   show a = genericShow a
+
 instance encodeJsonLiteralStringExample :: EncodeJson LiteralStringExample where
   encodeJson a = encodeLiteralSumWithTransform identity a
+
 instance decodeJsonLiteralStringExample :: DecodeJson LiteralStringExample where
   decodeJson a = decodeLiteralSumWithTransform identity a
 
@@ -57,12 +61,15 @@ diffEncodingOptions = defaultEncoding
   }
 
 data DiffEncoding = A | B Int
+
 derive instance eqDiffEncoding :: Eq DiffEncoding
 derive instance genericDiffEncoding :: Generic DiffEncoding _
 instance showDiffENcoding :: Show DiffEncoding where
   show a = genericShow a
+
 instance encodeJsonDiffEncoding :: EncodeJson DiffEncoding where
   encodeJson a = genericEncodeJsonWith diffEncodingOptions a
+
 instance decodeJsonDiffEncoding :: DecodeJson DiffEncoding where
   decodeJson a = genericDecodeJsonWith diffEncodingOptions a
 
@@ -72,22 +79,28 @@ unwrapSingleArgsOptions = defaultEncoding
   }
 
 data UnwrapSingleArgs = U0 Int | U1 Int Int
+
 derive instance eqUnwrapSingleArgs :: Eq UnwrapSingleArgs
 derive instance genericUnwrapSingleArgs :: Generic UnwrapSingleArgs _
 instance showUnwrapSingleArgs :: Show UnwrapSingleArgs where
   show a = genericShow a
+
 instance encodeJsonUnwrapSingleArgs :: EncodeJson UnwrapSingleArgs where
   encodeJson a = genericEncodeJsonWith unwrapSingleArgsOptions a
+
 instance decodeJsonUnwrapSingleArgs :: DecodeJson UnwrapSingleArgs where
   decodeJson a = genericDecodeJsonWith unwrapSingleArgsOptions a
 
 data IgnoreNullaryArgs = NA0 | NA1 Int
+
 derive instance eqIgnoreNullaryArgs :: Eq IgnoreNullaryArgs
 derive instance genericIgnoreNullaryArgs :: Generic IgnoreNullaryArgs _
 instance showIgnoreNullaryArgs :: Show IgnoreNullaryArgs where
   show a = genericShow a
+
 instance encodeJsonIgnoreNullaryArgs :: EncodeJson IgnoreNullaryArgs where
   encodeJson a = genericEncodeJson a
+
 instance decodeJsonIgnoreNullaryArgs :: DecodeJson IgnoreNullaryArgs where
   decodeJson a = genericDecodeJson a
 
@@ -98,8 +111,8 @@ main :: Effect Unit
 main = do
   example $ Either $ Left "foo"
   example $ Either $ Right $ Either $ Left "foo"
-  example $ Record {foo: 42, bar: "bar"}
-  example $ Nested {foo: {nested: 42}, bar: "bar"}
+  example $ Record { foo: 42, bar: "bar" }
+  example $ Nested { foo: { nested: 42 }, bar: "bar" }
   example $ Product 1 2 $ Either $ Left "foo"
   example $ Frikandel
   example $ A
@@ -131,8 +144,9 @@ main = do
     assert $ parsed == Right original
     log $ "--------------------------------------------------------------------------------"
 
-  testLiteralSumWithTransform :: forall a rep
-    . Show a
+  testLiteralSumWithTransform
+    :: forall a rep
+     . Show a
     => Eq a
     => Generic a rep
     => EncodeLiteral rep


### PR DESCRIPTION

**Description of the change**
Introduces the [`purs-tidy`](https://github.com/natefaubion/purescript-tidy) formatter. This formatter is a lightly opinionated tool we use to maintain a consistent style in the contrib libraries.

We ordinarily restrict to tools provided by the `core` or `contrib` projects. This tool is not, but it was developed and is maintained by core team members, and because it's a formatter it can't block maintenance or release of this library even in the event something goes catastrophically wrong with it.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation in the README and/or documentation directory
- [x] Added a test for the contribution (if applicable)
